### PR TITLE
Compute maximum speed for blur free photos

### DIFF
--- a/src/plan_computation.py
+++ b/src/plan_computation.py
@@ -38,7 +38,8 @@ def compute_speed_during_photo_capture(
     Returns:
         The speed at which the drone should move during photo capture.
     """
-    raise NotImplementedError()
+    gsd = compute_ground_sampling_distance(camera, dataset_spec.height)
+    return (allowed_movement_px * gsd) / (dataset_spec.exposure_time_ms / 1000)
 
 
 def generate_photo_plan_on_grid(


### PR DESCRIPTION
Computing the maximum speed for blur free photos
Experiment 1 (change the height of the dataspec):
<img width="629" height="250" alt="week5 experiment1" src="https://github.com/user-attachments/assets/3543775e-2130-434f-b44e-27994b6e4ea5" />
Experiment 2 (change the allowed pixel movement):
<img width="628" height="232" alt="week5 experiment2" src="https://github.com/user-attachments/assets/a128cb01-94d2-4f65-8d61-ce972fbfeca8" />
